### PR TITLE
fix:Update all CLI outputs to use colored output [#16]

### DIFF
--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"loki/internal/core"
+	"loki/internal/utils"
 )
 
 func Add(files []string) {
@@ -11,5 +12,5 @@ func Add(files []string) {
 	for _, f := range files {
 		repo.AddFile(f)
 	}
-	fmt.Println("Files added to staging area")
+	fmt.Println(utils.ColorText("Files added to staging area", "success"))
 }

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"loki/internal/utils"
 	"os"
 	"path/filepath"
 )
@@ -21,5 +22,5 @@ func Init() {
 
 	cwd, _ := os.Getwd()
 	absPath, _ := filepath.Abs(cwd)
-	fmt.Printf("Initialized empty Loki repository at %s\n", absPath)
+	fmt.Printf(utils.ColorText("Initialized empty Loki repository at %s\n","success"), absPath)
 }

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -3,16 +3,17 @@ package commands
 import (
 	"fmt"
 	"loki/internal/core"
+	"loki/internal/utils"
 )
 
 func Status() {
 	repo := core.OpenRepository()
 	files := repo.Status()
 	if len(files) == 0 {
-		fmt.Println("No files staged to commit")
+		fmt.Println(utils.ColorText("No files staged to commit", "warning"))
 		return
 	}
-	fmt.Println("Changes to be committed:")
+	fmt.Println(utils.ColorText("Changes to be committed:", "info"))
 	for _, fs := range files {
 		fmt.Printf("        %s:   %s\n", fs.Status, fs.Name)
 	}

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"loki/internal/utils"
 )
 
 type Repository struct {
@@ -19,11 +20,11 @@ type Repository struct {
 func OpenRepository() *Repository {
 	cwd, err := os.Getwd()
 	if err != nil {
-		panic("Could not get current working directory")
+		panic(utils.ColorText("Could not get current working directory", "error"))
 	}
 	repoRoot, ok := IsRepoInitialized(cwd + string(os.PathSeparator))
 	if !ok {
-		fmt.Fprintln(os.Stderr, "fatal: not a loki repository (or any of the parent directories)")
+		fmt.Fprintln(os.Stderr, utils.ColorText("fatal: not a loki repository (or any of the parent directories)", "error"))
 		os.Exit(1)
 	}
 	return &Repository{
@@ -180,7 +181,7 @@ func (r *Repository) Status() []FileStatus {
 func (r *Repository) PrintLog() {
 	logs, err := os.ReadFile(filepath.Join(r.store.GiveRoot(), "commits.log"))
 	if err != nil {
-		fmt.Println("No commit found.")
+		fmt.Println(utils.ColorText("No commit found.", "error"))
 		return
 	}
 	lines := strings.Split(string(logs), "\n")
@@ -192,6 +193,6 @@ func (r *Repository) PrintLog() {
 		if len(parts) < 2 {
 			continue
 		}
-		fmt.Printf("%s %s\n", parts[0], parts[1])
+		fmt.Printf(utils.ColorText("%s %s\n", "info"), parts[0], parts[1])
 	}
 }


### PR DESCRIPTION
Closes #16 
File changed:
- internal/commands/add.go
- internal/commands/init.go
- internal/commands/status.go
- internal/core/repository.go 
