### PR TITLE
fix: resolve repository check bypass on global execution

### DIFF
--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -18,7 +18,13 @@ func main() {
 
 	cwd, _ := os.Getwd()
 	absPath, _ := filepath.Abs(cwd)
-	if os.Args[0] == "./loki" && os.Args[1] != "help" && os.Args[1] != "init" {
+	noRepoRequired := map[string]bool{
+		"init":    true,
+		"help":    true,
+		"version": true,
+	}
+
+	if !noRepoRequired[os.Args[1]] {
 		_, check := core.IsRepoInitialized(absPath)
 		if !check {
 			fmt.Println(utils.ColorText("fatal:", "error") + utils.ColorText(string(cwd), "notice") + utils.ColorText(" not a loki repository \n(or any of the parent directories)", "error"))


### PR DESCRIPTION
Fixes #36 

### Description
This PR resolves the issue where the repository initialization check was bypassed if the Loki binary was run globally from the system PATH. 

The previous logic relied on `os.Args[0] == "./loki"`, which fails when the command is invoked simply as `loki` or via an absolute path.

### Changes Made
- Removed the hardcoded `os.Args[0]` check.
- Introduced a `noRepoRequired` map to explicitly whitelist commands that do not need a repository (e.g., `init`, `help`, `version`).
- Ensured that for any other command, `core.IsRepoInitialized(cwd)` is strictly executed, preventing commands from running outside a Loki repository.
