### PR TITLE
Issue 40

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,71 @@ Initialized empty Loki repository at /home/user/myproject/.loki
 
 ---
 
+
+## System-wide installation (Linux / macOS / Windows)
+
+Install the built `loki` binary to a system folder and add that folder to the system PATH.
+
+### Linux / macOS (system-wide)
+Build then install to /usr/local/bin (or Apple Silicon: /opt/homebrew/bin):
+
+```sh
+# from project root
+go build -o loki ./cmd/loki
+
+# install (requires sudo)
+sudo install -m 0755 loki /usr/local/bin/loki
+
+# or for Apple Silicon Homebrew prefix
+sudo install -m 0755 loki /opt/homebrew/bin/loki
+```
+
+Restart shells or open a new terminal. Verify:
+
+```sh
+which loki
+loki --help
+```
+
+### Windows (system-wide — Administrator)
+
+PowerShell (run as Administrator):
+
+```powershell
+# path to the built loki.exe
+$src = "C:\path\to\loki.exe"
+$dst = "C:\Program Files\Loki"
+
+New-Item -ItemType Directory -Path $dst -Force
+Copy-Item $src -Destination $dst -Force
+
+$machinePath = [Environment]::GetEnvironmentVariable('Path','Machine')
+if ($machinePath -notlike "*$dst*") {
+  [Environment]::SetEnvironmentVariable('Path', "$machinePath;$dst", 'Machine')
+}
+```
+
+CMD (run as Administrator):
+
+```bat
+mkdir "C:\Program Files\Loki"
+copy "C:\path\to\loki.exe" "C:\Program Files\Loki\loki.exe"
+setx /M PATH "%PATH%;C:\Program Files\Loki"
+```
+
+Restart shells or sign out/in. Verify:
+
+```powershell
+where loki
+loki --help
+```
+
+Notes:
+- These changes are persistent system-wide.
+- Use the appropriate admin privileges and replace the paths above with the actual build locations.
+
+---
+
 ## CI
 
 This project includes a GitHub Actions CI workflow that automatically builds and tests Loki on every push and pull request.

--- a/cmd/loki/main.go
+++ b/cmd/loki/main.go
@@ -10,6 +10,12 @@ import (
 	"loki/internal/utils"
 )
 
+var noRepoRequired = map[string]bool{
+	"init":   true,
+	"help":   true,
+	"config": true,
+}
+
 func main() {
 	if len(os.Args) < 2 {
 		commands.Help()
@@ -18,11 +24,6 @@ func main() {
 
 	cwd, _ := os.Getwd()
 	absPath, _ := filepath.Abs(cwd)
-	noRepoRequired := map[string]bool{
-		"init":    true,
-		"help":    true,
-		"version": true,
-	}
 
 	if !noRepoRequired[os.Args[1]] {
 		_, check := core.IsRepoInitialized(absPath)

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -41,7 +41,7 @@ func Config(args []string) {
 	if level == "global" {
 		cfg.LoadPath(config.GlobalConfigPath())
 	} else if level == "system" {
-		cfg.LoadPath(config.SystemConfigPath)
+		cfg.LoadPath(config.SystemConfigPath())
 	} else {
 		cfg.LoadPath(config.LocalConfigPath(repoRoot))
 	}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -27,9 +27,24 @@ func Config(args []string) {
 		}
 	}
 
-	repoRoot := config.FindRepoRoot(os.Getenv("PWD"))
 	cfg := config.NewConfig()
-	cfg.Load(repoRoot)
+	repoRoot := ""
+	if level == "local" {
+		cwd, _ := os.Getwd()
+		repoRoot = config.FindRepoRoot(cwd)
+		if repoRoot == "" {
+			fmt.Println(utils.ColorText("repo root required for local config", "error"))
+			return
+		}
+	}
+
+	if level == "global" {
+		cfg.LoadPath(config.GlobalConfigPath())
+	} else if level == "system" {
+		cfg.LoadPath(config.SystemConfigPath)
+	} else {
+		cfg.LoadPath(config.LocalConfigPath(repoRoot))
+	}
 
 	if value == "" {
 		// Get

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,13 +5,28 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 const (
-	SystemConfigPath = "/etc/loki/config"
-	RepoConfigPath   = ".loki/config"
+	RepoConfigPath = ".loki/config"
 )
+
+// SystemConfigPath returns the OS-appropriate system config location.
+func SystemConfigPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		if pd := os.Getenv("PROGRAMDATA"); pd != "" {
+			return filepath.Join(pd, "loki", "config")
+		}
+		return filepath.Join(string(os.PathSeparator), "ProgramData", "loki", "config")
+	case "darwin":
+		return filepath.Join(string(os.PathSeparator), "Library", "Application Support", "loki", "config")
+	default:
+		return filepath.Join(string(os.PathSeparator), "etc", "loki", "config")
+	}
+}
 
 type Config struct {
 	values map[string]string
@@ -23,10 +38,14 @@ func NewConfig() *Config {
 
 func (c *Config) Load(repoRoot string) error {
 	// System
-	c.loadFile(SystemConfigPath)
+	c.loadFile(SystemConfigPath())
 	// User
-	userPath := GlobalConfigPath()
-	c.loadFile(userPath)
+	// Load XDG user config (if XDG_CONFIG_HOME set) then fallback global file
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		c.loadFile(filepath.Join(xdg, "loki", "config"))
+	}
+	// fallback
+	c.loadFile(GlobalFallbackPath())
 	// Repo
 	if repoRoot != "" {
 		repoPath := filepath.Join(repoRoot, RepoConfigPath)
@@ -36,6 +55,19 @@ func (c *Config) Load(repoRoot string) error {
 }
 
 func GlobalConfigPath() string {
+	// If XDG_CONFIG_HOME is set, prefer $XDG_CONFIG_HOME/loki/config
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "loki", "config")
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".lokiconfig")
+	}
+	return filepath.Join(homeDir, ".lokiconfig")
+}
+
+// GlobalFallbackPath returns the legacy fallback user config (~/.lokiconfig)
+func GlobalFallbackPath() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".", ".lokiconfig")
@@ -79,9 +111,14 @@ func (c *Config) Get(key string) string {
 func (c *Config) Set(level, repoRoot, key, value string) error {
 	var path string
 	if level == "system" {
-		path = SystemConfigPath
+		path = SystemConfigPath()
 	} else if level == "global" {
-		path = GlobalConfigPath()
+		// Prefer XDG path when XDG_CONFIG_HOME is set, otherwise use fallback
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			path = filepath.Join(xdg, "loki", "config")
+		} else {
+			path = GlobalFallbackPath()
+		}
 	} else if level == "local" {
 		if repoRoot == "" {
 			return errors.New("repo root required for local config")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	SystemConfigPath = "/etc/loki/config"
-	UserConfigPath   = ".loki/config"
 	RepoConfigPath   = ".loki/config"
 )
 
@@ -26,7 +25,7 @@ func (c *Config) Load(repoRoot string) error {
 	// System
 	c.loadFile(SystemConfigPath)
 	// User
-	userPath := filepath.Join(os.Getenv("HOME"), UserConfigPath)
+	userPath := GlobalConfigPath()
 	c.loadFile(userPath)
 	// Repo
 	if repoRoot != "" {
@@ -34,6 +33,22 @@ func (c *Config) Load(repoRoot string) error {
 		c.loadFile(repoPath)
 	}
 	return nil
+}
+
+func GlobalConfigPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".lokiconfig")
+	}
+	return filepath.Join(homeDir, ".lokiconfig")
+}
+
+func LocalConfigPath(repoRoot string) string {
+	return filepath.Join(repoRoot, RepoConfigPath)
+}
+
+func (c *Config) LoadPath(path string) {
+	c.loadFile(path)
 }
 
 func (c *Config) loadFile(path string) {
@@ -66,12 +81,12 @@ func (c *Config) Set(level, repoRoot, key, value string) error {
 	if level == "system" {
 		path = SystemConfigPath
 	} else if level == "global" {
-		path = filepath.Join(os.Getenv("HOME"), UserConfigPath)
+		path = GlobalConfigPath()
 	} else if level == "local" {
 		if repoRoot == "" {
 			return errors.New("repo root required for local config")
 		}
-		path = filepath.Join(repoRoot, RepoConfigPath)
+		path = LocalConfigPath(repoRoot)
 	} else {
 		return errors.New("invalid config level")
 	}
@@ -99,7 +114,9 @@ func setConfigValue(path, key, value string) error {
 		lines = append(lines, key+"="+value)
 	}
 
-	os.MkdirAll(filepath.Dir(path), 0755)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
 	file, err := os.Create(path)
 	if err != nil {
 		return err

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -8,8 +8,8 @@ import (
 func FindRepoRoot(start string) string {
 	dir := start
 	for {
-		configPath := filepath.Join(dir, ".loki/config")
-		if _, err := os.Stat(configPath); err == nil {
+		headPath := filepath.Join(dir, ".loki", "HEAD")
+		if _, err := os.Stat(headPath); err == nil {
 			return dir
 		}
 		parent := filepath.Dir(dir)


### PR DESCRIPTION
Closes #40 
fixed repo guard: 
- out scoped noRepoRequired map

fixed config file path: 
- global level config credentials stores in .lokiconfig in home root path 
- system level config credentials stores in 

updated docs for loki system path:
- for system wide installation of loki
- window environment path logic is not working for now
